### PR TITLE
Enable unique external accounts

### DIFF
--- a/src/AccountSelector.js
+++ b/src/AccountSelector.js
@@ -18,6 +18,9 @@ function Main (props) {
   const { setAccountAddress } = props;
   const [accountSelected, setAccountSelected] = useState('');
 
+  // const { setAccountAddress_inital } = props;
+  // const [accountSelected_inital, setAccountSelected_inital] = useState('');
+
   // Get the list of accounts we possess the private key for
   const keyringOptions = keyring.getPairs().map(account => ({
     key: account.address,
@@ -34,6 +37,12 @@ function Main (props) {
     setAccountAddress(initialAddress);
     setAccountSelected(initialAddress);
   }, [setAccountAddress, initialAddress]);
+
+  // useEffect(() => {
+  //   setAccountAddress_inital(initialAddress);
+  //   setAccountSelected_inital(initialAddress);
+  // }, [setAccountAddress, initialAddress]);
+
 
   const onChange = address => {
     // Update state with new account address

--- a/src/AccountSelector.js
+++ b/src/AccountSelector.js
@@ -18,9 +18,6 @@ function Main (props) {
   const { setAccountAddress } = props;
   const [accountSelected, setAccountSelected] = useState('');
 
-  // const { setAccountAddress_inital } = props;
-  // const [accountSelected_inital, setAccountSelected_inital] = useState('');
-
   // Get the list of accounts we possess the private key for
   const keyringOptions = keyring.getPairs().map(account => ({
     key: account.address,
@@ -37,11 +34,6 @@ function Main (props) {
     setAccountAddress(initialAddress);
     setAccountSelected(initialAddress);
   }, [setAccountAddress, initialAddress]);
-
-  // useEffect(() => {
-  //   setAccountAddress_inital(initialAddress);
-  //   setAccountSelected_inital(initialAddress);
-  // }, [setAccountAddress, initialAddress]);
 
 
   const onChange = address => {

--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,8 @@ import { ApnTokenInfo } from './ApnTokenInfo';
 import LeafletMap from './LeafletMap';
 import GeoJsonMap from './GeoJsonMap';
 
+import Register_new_account from './Register_new_account';
+
 
 function Main () {
   const [accountAddress, setAccountAddress] = useState(null);
@@ -71,7 +73,7 @@ function Main () {
               <Events />
             </Grid.Row>
           </div>
-          {/* <div style={{width: '100%'}}>
+          <div style={{width: '100%'}}>
             <Grid.Row>
               <Interactor accountPair={accountPair} />
             </Grid.Row>
@@ -79,7 +81,13 @@ function Main () {
           <Grid.Row>
             <TemplateModule accountPair={accountPair} />
           </Grid.Row>
-          <Grid.Row stretched> */}
+          <Grid.Row>
+            <Register_new_account accountPair={accountPair} />
+          </Grid.Row>
+          {/* <Grid.Row stretched> */}
+          <Grid.Row>
+            <Balances accountPair={accountPair} />
+          </Grid.Row>
         </Grid>
       </Container>
       <Divider />

--- a/src/App.js
+++ b/src/App.js
@@ -73,21 +73,21 @@ function Main () {
               <Events />
             </Grid.Row>
           </div>
-          <div style={{width: '100%'}}>
+          {/* <div style={{width: '100%'}}>
             <Grid.Row>
               <Interactor accountPair={accountPair} />
             </Grid.Row>
           </div>
           <Grid.Row>
             <TemplateModule accountPair={accountPair} />
-          </Grid.Row>
+          </Grid.Row> */}
           <Grid.Row>
             <Register_new_account accountPair={accountPair} />
           </Grid.Row>
           {/* <Grid.Row stretched> */}
-          <Grid.Row>
+          {/* <Grid.Row>
             <Balances accountPair={accountPair} />
-          </Grid.Row>
+          </Grid.Row> */}
         </Grid>
       </Container>
       <Divider />

--- a/src/Register_new_account.js
+++ b/src/Register_new_account.js
@@ -36,11 +36,6 @@ export default function Main (props) {
   keyringState === 'READY' &&
   keyring.getPair(initialAddress);
 
-  // useEffect(() => {
-  //   setAccountAddress(initialAddress);
-  //   setAccountSelected(initialAddress);
-  // }, [setAccountAddress, initialAddress]);
-
   if(!accountPair) return null;
   return (
     <Grid.Column width={8}>

--- a/src/Register_new_account.js
+++ b/src/Register_new_account.js
@@ -8,6 +8,8 @@ export default function Main (props) {
   const [status, setStatus] = useState(null);
   const [formState, setFormState] = useState({ addressFrom: null, addressTo: null, amount: 0 });
   const { accountPair } = props;
+  // const { setAccountAddress } = props;
+
 
   const onChange = (_, data) => {
     setFormState(prev => ({ ...prev, [data.state]: data.value }));
@@ -34,6 +36,12 @@ export default function Main (props) {
   keyringState === 'READY' &&
   keyring.getPair(initialAddress);
 
+  // useEffect(() => {
+  //   setAccountAddress(initialAddress);
+  //   setAccountSelected(initialAddress);
+  // }, [setAccountAddress, initialAddress]);
+
+  if(!accountPair) return null;
   return (
     <Grid.Column width={8}>
       <h1>Register New Account</h1>
@@ -48,7 +56,7 @@ export default function Main (props) {
               palletRpc: 'balances',
               callable: 'transfer',
               inputParams: [
-                accountPair.address, 
+                accountPair.address,  // issue here with accountPair being null on init. it doesnt like this. 
                 1000000000000000
               ],
               interxType: 'EXTRINSIC',

--- a/src/Register_new_account.js
+++ b/src/Register_new_account.js
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import { Form, Input, Grid, Label, Icon } from 'semantic-ui-react';
+import { TxButton } from './substrate-lib/components';
+import { encodeApn, base64ToArray } from './helpers.js';
+import { SubstrateContextProvider, useSubstrate } from './substrate-lib';
+
+export default function Main (props) {
+  const [status, setStatus] = useState(null);
+  const [formState, setFormState] = useState({ addressFrom: null, addressTo: null, amount: 0 });
+  const { accountPair } = props;
+  // const { initialAddress } = props;
+
+  const onChange = (_, data) => {
+    setFormState(prev => ({ ...prev, [data.state]: data.value }));
+    setAddressFromEncoded(encodeApn(addressFrom, true));
+    setAddressToEncoded(addressTo);
+  };
+
+  const { apiState, keyring, keyringState, apiError } = useSubstrate();
+
+  const [addressFromEncoded, setAddressFromEncoded] = useState('');
+  const [addressToEncoded, setAddressToEncoded] = useState('');
+
+  const { addressFrom, addressTo, amount } = formState;
+
+  // Get the list of accounts we possess the private key for
+  const keyringOptions = keyring.getPairs().map(account => ({
+    key: account.address,
+    value: account.address,
+    text: account.meta.name.toUpperCase(),
+    icon: 'user'
+  }));
+
+  const initialAddress =
+    keyringOptions.length > 0 ? keyringOptions[0].value : '';
+
+
+  const accountPair1 =
+  initialAddress &&
+  keyringState === 'READY' &&
+  keyring.getPair(initialAddress);
+
+  return (
+    <Grid.Column width={8}>
+      <h1>Register New Account</h1>
+      <Form>
+        {/* <Form.Field>
+          <Input
+            fluid
+            label='From'
+            type='text'
+            placeholder='address'
+            state='addressFrom'
+            onChange={onChange}
+          />
+        </Form.Field> */}
+        <Form.Field>
+          <Input
+            fluid
+            label='To'
+            type='text'
+            placeholder='address'
+            state='addressTo'
+            onChange={onChange}
+          />
+        </Form.Field>
+        {/* <Form.Field>
+          <Input
+            fluid
+            label='Amount'
+            type='number'
+            state='amount'
+            onChange={onChange}
+          />
+        </Form.Field> */}
+        <Form.Field style={{ textAlign: 'center' }}>
+          <TxButton
+            accountPair={accountPair1}
+            label='Submit'
+            type='SIGNED-TX'
+            setStatus={setStatus}
+            attrs={{
+              palletRpc: 'balances',
+              callable: 'transfer',
+              inputParams: [
+                addressTo, 
+                10000
+              ],
+              interxType: 'EXTRINSIC',
+              paramFields: [
+                true, true
+              ]
+            }}
+          />
+        </Form.Field>
+        <div style={{ overflowWrap: 'break-word' }}>{status}</div>
+      </Form>
+    </Grid.Column>
+  );
+}

--- a/src/Register_new_account.js
+++ b/src/Register_new_account.js
@@ -49,7 +49,7 @@ export default function Main (props) {
               callable: 'transfer',
               inputParams: [
                 accountPair.address, 
-                100000000000
+                1000000000000000
               ],
               interxType: 'EXTRINSIC',
               paramFields: [

--- a/src/Register_new_account.js
+++ b/src/Register_new_account.js
@@ -8,7 +8,6 @@ export default function Main (props) {
   const [status, setStatus] = useState(null);
   const [formState, setFormState] = useState({ addressFrom: null, addressTo: null, amount: 0 });
   const { accountPair } = props;
-  // const { initialAddress } = props;
 
   const onChange = (_, data) => {
     setFormState(prev => ({ ...prev, [data.state]: data.value }));
@@ -17,11 +16,6 @@ export default function Main (props) {
   };
 
   const { apiState, keyring, keyringState, apiError } = useSubstrate();
-
-  const [addressFromEncoded, setAddressFromEncoded] = useState('');
-  const [addressToEncoded, setAddressToEncoded] = useState('');
-
-  const { addressFrom, addressTo, amount } = formState;
 
   // Get the list of accounts we possess the private key for
   const keyringOptions = keyring.getPairs().map(account => ({
@@ -44,35 +38,6 @@ export default function Main (props) {
     <Grid.Column width={8}>
       <h1>Register New Account</h1>
       <Form>
-        {/* <Form.Field>
-          <Input
-            fluid
-            label='From'
-            type='text'
-            placeholder='address'
-            state='addressFrom'
-            onChange={onChange}
-          />
-        </Form.Field> */}
-        <Form.Field>
-          <Input
-            fluid
-            label='To'
-            type='text'
-            placeholder='address'
-            state='addressTo'
-            onChange={onChange}
-          />
-        </Form.Field>
-        {/* <Form.Field>
-          <Input
-            fluid
-            label='Amount'
-            type='number'
-            state='amount'
-            onChange={onChange}
-          />
-        </Form.Field> */}
         <Form.Field style={{ textAlign: 'center' }}>
           <TxButton
             accountPair={accountPair1}
@@ -83,8 +48,8 @@ export default function Main (props) {
               palletRpc: 'balances',
               callable: 'transfer',
               inputParams: [
-                addressTo, 
-                10000
+                accountPair.address, 
+                100000000000
               ],
               interxType: 'EXTRINSIC',
               paramFields: [

--- a/src/Register_new_account.js
+++ b/src/Register_new_account.js
@@ -44,7 +44,7 @@ export default function Main (props) {
   if(!accountPair) return null;
   return (
     <Grid.Column width={8}>
-      <h1>Register New Account</h1>
+      <h1>Register Injected Account on BLX</h1>
       <Form>
         <Form.Field style={{ textAlign: 'center' }}>
           <TxButton


### PR DESCRIPTION
Enables unique accounts! 👑

added functionality to 'register' injected web3 accounts which are added via polkadot js extension. 

basically its a hardcoded balance transfer from alice to whichever account is selected in the account selector (relevant variable is: accountPair) 

by transfering some balance over the injected account can claim parcels and do other stuff. amount being transfered over is small (limited by some type issues) so you may need to Register your account multiple times if it starts to error because of low funds